### PR TITLE
Multihashing-Fix: Support older machines

### DIFF
--- a/multihashing.cc
+++ b/multihashing.cc
@@ -3,6 +3,7 @@
 #include <v8.h>
 #include <stdint.h>
 #include <nan.h>
+#include <stdexcept>
 
 //#if (defined(__AES__) && (__AES__ == 1)) || defined(__APPLE__) || defined(__ARM_ARCH)
 //#else


### PR DESCRIPTION
Older OS installs do not correctly bootstrap the stdexcept library.
This breaks the throw std::domain_error("Unknown RandomX algo");
As the std::domain_error is not imported.