### PR TITLE
Cache Hash support

### DIFF
--- a/multihashing.cc
+++ b/multihashing.cc
@@ -202,7 +202,7 @@ static xmrig::cn_hash_fun get_cn_fn(const int algo) {
     case 15: return FNA(CN_ZLS);
     case 16: return FNA(CN_DOUBLE);
     case 17: return FNA(CN_CCX);
-    case 17: return FNA(CN_CACHE_HASH);
+    case 18: return FNA(CN_CACHE_HASH);
     default: return FN(CN_R);
   }
 }

--- a/multihashing.cc
+++ b/multihashing.cc
@@ -202,6 +202,7 @@ static xmrig::cn_hash_fun get_cn_fn(const int algo) {
     case 15: return FNA(CN_ZLS);
     case 16: return FNA(CN_DOUBLE);
     case 17: return FNA(CN_CCX);
+    case 17: return FNA(CN_CACHE_HASH);
     default: return FN(CN_R);
   }
 }

--- a/xmrig-override/base/crypto/Algorithm.h
+++ b/xmrig-override/base/crypto/Algorithm.h
@@ -65,6 +65,7 @@ public:
         CN_PICO_0,     // "cn-pico"          CryptoNight-Pico
         CN_PICO_TLO,   // "cn-pico/tlo"      CryptoNight-Pico (TLO)
         CN_CCX,        // "cn/ccx"           Conceal (CCX)
+        CN_CACHE_HASH, // "cn/cache_hash"    Cache (CXCHE)
         CN_GPU,        // "cn/gpu"           CryptoNight-GPU (Ryo).
         // CryptoNight variants must be above this line
         // (index of RX_0 is used in loops as "end of all CN families" marker)

--- a/xmrig/crypto/cn/CnAlgo.h
+++ b/xmrig/crypto/cn/CnAlgo.h
@@ -123,6 +123,10 @@ public:
             return 0x1FFFC0;
         }
 #       endif
+        
+       if (algo == Algorithm::CN_CACHE_HASH) {
+           return 0x1FFFA0;
+       }
 
         return ((memory(algo) - 1) / 16) * 16;
     }
@@ -140,7 +144,6 @@ public:
         case Algorithm::CN_HEAVY_XHV:
 #       endif
         case Algorithm::CN_CCX:
-            return Algorithm::CN_0;
         case Algorithm::CN_CACHE_HASH:
             return Algorithm::CN_0;
 
@@ -191,7 +194,7 @@ template<> constexpr inline Algorithm::Id CnAlgo<Algorithm::CN_LITE_0>::base() c
 template<> constexpr inline Algorithm::Id CnAlgo<Algorithm::CN_HEAVY_0>::base() const       { return Algorithm::CN_0; }
 template<> constexpr inline Algorithm::Id CnAlgo<Algorithm::CN_HEAVY_XHV>::base() const     { return Algorithm::CN_0; }
 template<> constexpr inline Algorithm::Id CnAlgo<Algorithm::CN_CCX>::base() const           { return Algorithm::CN_0; }
-template<> constexpr inline Algorithm::Id CnAlgo<Algorithm::CN_CACHE_HASH>::base() const           { return Algorithm::CN_0; }
+template<> constexpr inline Algorithm::Id CnAlgo<Algorithm::CN_CACHE_HASH>::base() const    { return Algorithm::CN_0; }
 template<> constexpr inline Algorithm::Id CnAlgo<Algorithm::CN_1>::base() const             { return Algorithm::CN_1; }
 template<> constexpr inline Algorithm::Id CnAlgo<Algorithm::CN_FAST>::base() const          { return Algorithm::CN_1; }
 template<> constexpr inline Algorithm::Id CnAlgo<Algorithm::CN_RTO>::base() const           { return Algorithm::CN_1; }

--- a/xmrig/crypto/cn/CnAlgo.h
+++ b/xmrig/crypto/cn/CnAlgo.h
@@ -81,6 +81,8 @@ public:
 #       endif
         case Algorithm::CN_CCX:
             return CN_ITER / 2;
+        case Algorithm::CN_CACHE_HASH:
+            return 0x50000;
 
         case Algorithm::CN_RWZ:
         case Algorithm::CN_ZLS:
@@ -139,6 +141,8 @@ public:
 #       endif
         case Algorithm::CN_CCX:
             return Algorithm::CN_0;
+        case Algorithm::CN_CACHE_HASH:
+            return Algorithm::CN_0;
 
         case Algorithm::CN_1:
         case Algorithm::CN_FAST:
@@ -187,6 +191,7 @@ template<> constexpr inline Algorithm::Id CnAlgo<Algorithm::CN_LITE_0>::base() c
 template<> constexpr inline Algorithm::Id CnAlgo<Algorithm::CN_HEAVY_0>::base() const       { return Algorithm::CN_0; }
 template<> constexpr inline Algorithm::Id CnAlgo<Algorithm::CN_HEAVY_XHV>::base() const     { return Algorithm::CN_0; }
 template<> constexpr inline Algorithm::Id CnAlgo<Algorithm::CN_CCX>::base() const           { return Algorithm::CN_0; }
+template<> constexpr inline Algorithm::Id CnAlgo<Algorithm::CN_CACHE_HASH>::base() const           { return Algorithm::CN_0; }
 template<> constexpr inline Algorithm::Id CnAlgo<Algorithm::CN_1>::base() const             { return Algorithm::CN_1; }
 template<> constexpr inline Algorithm::Id CnAlgo<Algorithm::CN_FAST>::base() const          { return Algorithm::CN_1; }
 template<> constexpr inline Algorithm::Id CnAlgo<Algorithm::CN_RTO>::base() const           { return Algorithm::CN_1; }
@@ -208,6 +213,7 @@ template<> constexpr inline uint32_t CnAlgo<Algorithm::CN_ZLS>::iterations() con
 template<> constexpr inline uint32_t CnAlgo<Algorithm::CN_PICO_0>::iterations() const       { return CN_ITER / 8; }
 template<> constexpr inline uint32_t CnAlgo<Algorithm::CN_PICO_TLO>::iterations() const     { return CN_ITER / 8; }
 template<> constexpr inline uint32_t CnAlgo<Algorithm::CN_CCX>::iterations() const          { return CN_ITER / 2; }
+template<> constexpr inline uint32_t CnAlgo<Algorithm::CN_CACHE_HASH>::iterations() const   { return 0x50000; }
 template<> constexpr inline uint32_t CnAlgo<Algorithm::CN_GPU>::iterations() const          { return 0xC000; }
 
 
@@ -222,6 +228,7 @@ template<> constexpr inline size_t CnAlgo<Algorithm::CN_PICO_TLO>::memory() cons
 
 template<> constexpr inline uint32_t CnAlgo<Algorithm::CN_PICO_0>::mask() const             { return 0x1FFF0; }
 template<> constexpr inline uint32_t CnAlgo<Algorithm::CN_GPU>::mask() const                { return 0x1FFFC0; }
+template<> constexpr inline uint32_t CnAlgo<Algorithm::CN_CACHE_HASH>::mask() const         { return 0x1FFFA0; }
 
 
 } /* namespace xmrig */

--- a/xmrig/crypto/cn/CnHash.cpp
+++ b/xmrig/crypto/cn/CnHash.cpp
@@ -272,6 +272,8 @@ xmrig::CnHash::CnHash()
 
     ADD_FN(Algorithm::CN_CCX);
 
+    ADD_FN(Algorithm::CN_CACHE_HASH);
+
 #   ifdef XMRIG_ALGO_ARGON2
     m_map[Algorithm::AR2_CHUKWA][AV_SINGLE][Assembly::NONE]      = argon2::single_hash<Algorithm::AR2_CHUKWA>;
     m_map[Algorithm::AR2_CHUKWA][AV_SINGLE_SOFT][Assembly::NONE] = argon2::single_hash<Algorithm::AR2_CHUKWA>;

--- a/xmrig/crypto/cn/CryptoNight_arm.h
+++ b/xmrig/crypto/cn/CryptoNight_arm.h
@@ -498,7 +498,7 @@ inline void cryptonight_single_hash(const uint8_t *__restrict__ input, size_t si
     __m128i bx1  = _mm_set_epi64x(h0[9] ^ h0[11], h0[8] ^ h0[10]);
 
     __m128 conc_var;
-    if (ALGO == Algorithm::CN_CCX) {
+    if ((ALGO == Algorithm::CN_CCX) || (ALGO == Algorithm::CN_CACHE_HASH)) {
         conc_var = _mm_setzero_ps();
     }
 
@@ -508,7 +508,7 @@ inline void cryptonight_single_hash(const uint8_t *__restrict__ input, size_t si
         __m128i cx;
         if (IS_CN_HEAVY_TUBE || !SOFT_AES) {
             cx = _mm_load_si128(reinterpret_cast<const __m128i *>(&l0[idx0 & MASK]));
-            if (ALGO == Algorithm::CN_CCX) {
+            if ((ALGO == Algorithm::CN_CCX) || (ALGO == Algorithm::CN_CACHE_HASH)) {
                 cryptonight_conceal_tweak(cx, conc_var);
             }
         }
@@ -518,7 +518,7 @@ inline void cryptonight_single_hash(const uint8_t *__restrict__ input, size_t si
             cx = aes_round_tweak_div(cx, ax0);
         }
         else if (SOFT_AES) {
-            if (ALGO == Algorithm::CN_CCX) {
+            if ((ALGO == Algorithm::CN_CCX) || (ALGO == Algorithm::CN_CACHE_HASH)) {
                 cx = _mm_load_si128(reinterpret_cast<const __m128i*>(&l0[idx0 & MASK]));
                 cryptonight_conceal_tweak(cx, conc_var);
                 cx = soft_aesenc((uint32_t*)&cx, ax0);
@@ -720,7 +720,7 @@ inline void cryptonight_double_hash(const uint8_t *__restrict__ input, size_t si
     __m128i bx11 = _mm_set_epi64x(h1[9] ^ h1[11], h1[8] ^ h1[10]);
 
     __m128 conc_var0, conc_var1;
-    if (ALGO == Algorithm::CN_CCX) {
+    if ((ALGO == Algorithm::CN_CCX) || (ALGO == Algorithm::CN_CACHE_HASH)) {
         conc_var0 = _mm_setzero_ps();
         conc_var1 = _mm_setzero_ps();
     }
@@ -733,7 +733,7 @@ inline void cryptonight_double_hash(const uint8_t *__restrict__ input, size_t si
         if (IS_CN_HEAVY_TUBE || !SOFT_AES) {
             cx0 = _mm_load_si128((__m128i *) &l0[idx0 & MASK]);
             cx1 = _mm_load_si128((__m128i *) &l1[idx1 & MASK]);
-            if (ALGO == Algorithm::CN_CCX) {
+            if ((ALGO == Algorithm::CN_CCX) || (ALGO == Algorithm::CN_CACHE_HASH)) {
                 cryptonight_conceal_tweak(cx0, conc_var0);
                 cryptonight_conceal_tweak(cx1, conc_var1);
             }
@@ -746,7 +746,7 @@ inline void cryptonight_double_hash(const uint8_t *__restrict__ input, size_t si
             cx1 = aes_round_tweak_div(cx1, ax1);
         }
         else if (SOFT_AES) {
-            if (ALGO == Algorithm::CN_CCX) {
+            if ((ALGO == Algorithm::CN_CCX) || (ALGO == Algorithm::CN_CACHE_HASH)) {
                 cx0 = _mm_load_si128((__m128i *) &l0[idx0 & MASK]);
                 cx1 = _mm_load_si128((__m128i *) &l1[idx1 & MASK]);
                 cryptonight_conceal_tweak(cx0, conc_var0);

--- a/xmrig/crypto/cn/CryptoNight_x86.h
+++ b/xmrig/crypto/cn/CryptoNight_x86.h
@@ -623,7 +623,7 @@ inline void cryptonight_single_hash(const uint8_t *__restrict__ input, size_t si
     __m128i bx1   = _mm_set_epi64x(static_cast<int64_t>(h0[9] ^ h0[11]), static_cast<int64_t>(h0[8] ^ h0[10]));
 
     __m128 conc_var;
-    if (ALGO == Algorithm::CN_CCX) {
+    if ((ALGO == Algorithm::CN_CCX) || (ALGO == Algorithm::CN_CACHE_HASH)) {
         conc_var = _mm_setzero_ps();
         RESTORE_ROUNDING_MODE();
     }
@@ -632,7 +632,7 @@ inline void cryptonight_single_hash(const uint8_t *__restrict__ input, size_t si
         __m128i cx;
         if (IS_CN_HEAVY_TUBE || !SOFT_AES) {
             cx = _mm_load_si128(reinterpret_cast<const __m128i *>(&l0[idx0 & MASK]));
-            if (ALGO == Algorithm::CN_CCX) {
+            if ((ALGO == Algorithm::CN_CCX) || (ALGO == Algorithm::CN_CACHE_HASH)) {
                 cryptonight_conceal_tweak(cx, conc_var);
             }
         }
@@ -642,7 +642,7 @@ inline void cryptonight_single_hash(const uint8_t *__restrict__ input, size_t si
             cx = aes_round_tweak_div(cx, ax0);
         }
         else if (SOFT_AES) {
-            if (ALGO == Algorithm::CN_CCX) {
+            if ((ALGO == Algorithm::CN_CCX) || (ALGO == Algorithm::CN_CACHE_HASH)) {
                 cx = _mm_load_si128(reinterpret_cast<const __m128i*>(&l0[idx0 & MASK]));
                 cryptonight_conceal_tweak(cx, conc_var);
                 cx = soft_aesenc(&cx, ax0, reinterpret_cast<const uint32_t*>(saes_table));
@@ -1083,7 +1083,7 @@ inline void cryptonight_double_hash(const uint8_t *__restrict__ input, size_t si
     __m128i bx11 = _mm_set_epi64x(h1[9] ^ h1[11], h1[8] ^ h1[10]);
 
     __m128 conc_var0, conc_var1;
-    if (ALGO == Algorithm::CN_CCX) {
+    if ((ALGO == Algorithm::CN_CCX) || (ALGO == Algorithm::CN_CACHE_HASH)) {
         conc_var0 = _mm_setzero_ps();
         conc_var1 = _mm_setzero_ps();
         RESTORE_ROUNDING_MODE();
@@ -1097,7 +1097,7 @@ inline void cryptonight_double_hash(const uint8_t *__restrict__ input, size_t si
         if (IS_CN_HEAVY_TUBE || !SOFT_AES) {
             cx0 = _mm_load_si128(reinterpret_cast<const __m128i *>(&l0[idx0 & MASK]));
             cx1 = _mm_load_si128(reinterpret_cast<const __m128i *>(&l1[idx1 & MASK]));
-            if (ALGO == Algorithm::CN_CCX) {
+            if ((ALGO == Algorithm::CN_CCX) || (ALGO == Algorithm::CN_CACHE_HASH)) {
                 cryptonight_conceal_tweak(cx0, conc_var0);
                 cryptonight_conceal_tweak(cx1, conc_var1);
             }
@@ -1110,7 +1110,7 @@ inline void cryptonight_double_hash(const uint8_t *__restrict__ input, size_t si
             cx1 = aes_round_tweak_div(cx1, ax1);
         }
         else if (SOFT_AES) {
-            if (ALGO == Algorithm::CN_CCX) {
+            if ((ALGO == Algorithm::CN_CCX) || (ALGO == Algorithm::CN_CACHE_HASH)) {
                 cx0 = _mm_load_si128(reinterpret_cast<const __m128i*>(&l0[idx0 & MASK]));
                 cx1 = _mm_load_si128(reinterpret_cast<const __m128i*>(&l1[idx1 & MASK]));
                 cryptonight_conceal_tweak(cx0, conc_var0);
@@ -1279,7 +1279,7 @@ inline void cryptonight_double_hash(const uint8_t *__restrict__ input, size_t si
 #define CN_STEP1(a, b0, b1, c, l, ptr, idx, conc_var) \
     ptr = reinterpret_cast<__m128i*>(&l[idx & MASK]); \
     c = _mm_load_si128(ptr);                          \
-    if (ALGO == Algorithm::CN_CCX) {                  \
+    if ((ALGO == Algorithm::CN_CCX) || (ALGO == Algorithm::CN_CACHE_HASH)) { \
         cryptonight_conceal_tweak(c, conc_var);       \
     }
 
@@ -1383,7 +1383,7 @@ inline void cryptonight_double_hash(const uint8_t *__restrict__ input, size_t si
     __m128i bx##n##1 = _mm_set_epi64x(h##n[9] ^ h##n[11], h##n[8] ^ h##n[10]);                   \
     __m128i cx##n = _mm_setzero_si128();                                                         \
     __m128 conc_var##n;                                                                          \
-    if (ALGO == Algorithm::CN_CCX) {                                                             \
+    if ((ALGO == Algorithm::CN_CCX) || (ALGO == Algorithm::CN_CACHE_HASH)) {                     \
         conc_var##n = _mm_setzero_ps();                                                          \
     }                                                                                            \
     VARIANT4_RANDOM_MATH_INIT(n);
@@ -1425,7 +1425,7 @@ inline void cryptonight_triple_hash(const uint8_t *__restrict__ input, size_t si
     CONST_INIT(ctx[1], 1);
     CONST_INIT(ctx[2], 2);
     VARIANT2_SET_ROUNDING_MODE();
-    if (ALGO == Algorithm::CN_CCX) {
+    if ((ALGO == Algorithm::CN_CCX) || (ALGO == Algorithm::CN_CACHE_HASH)) {
         RESTORE_ROUNDING_MODE();
     }
 
@@ -1502,7 +1502,7 @@ inline void cryptonight_quad_hash(const uint8_t *__restrict__ input, size_t size
     CONST_INIT(ctx[2], 2);
     CONST_INIT(ctx[3], 3);
     VARIANT2_SET_ROUNDING_MODE();
-    if (ALGO == Algorithm::CN_CCX) {
+    if ((ALGO == Algorithm::CN_CCX) || (ALGO == Algorithm::CN_CACHE_HASH)) {
         RESTORE_ROUNDING_MODE();
     }
 
@@ -1587,7 +1587,7 @@ inline void cryptonight_penta_hash(const uint8_t *__restrict__ input, size_t siz
     CONST_INIT(ctx[3], 3);
     CONST_INIT(ctx[4], 4);
     VARIANT2_SET_ROUNDING_MODE();
-    if (ALGO == Algorithm::CN_CCX) {
+    if ((ALGO == Algorithm::CN_CCX) || (ALGO == Algorithm::CN_CACHE_HASH)) {
         RESTORE_ROUNDING_MODE();
     }
 


### PR DESCRIPTION
Cryptonight cache hash is a modified variant of cryptonight conceal.

https://github.com/xmrig/xmrig/pull/1894 - xmrig PR

https://letshash.it/cxche/ - current working pool supporting cache hash