### PR TITLE
Add mac build support to node-gyp bindings

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,11 +2,18 @@
     "targets": [
         {
             "target_name": "cryptonight-hashing",
+             'conditions': [
+                ['OS=="mac"', {
+                  'xcode_settings': {
+                    'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
+                  }
+                }]
+              ],
             "sources": [
                 '<!@(uname -a | grep "x86_64" >/dev/null && echo "xmrig/crypto/cn/asm/cn_main_loop.S" || echo)',
                 '<!@(uname -a | grep "x86_64" >/dev/null && echo "xmrig/crypto/cn/asm/CryptonightR_template.S" || echo)',
                 '<!@(uname -a | grep "x86_64" >/dev/null && echo "xmrig/crypto/cn/r/CryptonightR_gen.cpp" || echo)',
-                '<!@(uname -a | grep "x86_64" >/dev/null && (grep avx2 /proc/cpuinfo >/dev/null && echo "xmrig/crypto/cn/gpu/cn_gpu_avx.cpp" || echo) || echo)',
+                '<!@(uname -a | grep "x86_64" >/dev/null && (./check_cpu.sh avx2 && echo "xmrig/crypto/cn/gpu/cn_gpu_avx.cpp" || echo) || echo)',
                 '<!@(uname -a | grep "x86_64" >/dev/null && echo "xmrig/crypto/cn/gpu/cn_gpu_ssse3.cpp" || echo)',
                 '<!@(uname -a | grep "x86_64" >/dev/null || echo "xmrig/crypto/cn/gpu/cn_gpu_arm.cpp" || echo)',
                 '<!@(uname -a | grep "x86_64" >/dev/null && echo "xmrig-override/backend/cpu/platform/BasicCpuInfo.cpp" || echo)',
@@ -76,9 +83,9 @@
                 "xmrig/crypto/randomx/panthera/sha256.c",
                 "xmrig/crypto/randomx/panthera/yespower-opt.c",
 
-		"xmrig-override/crypto/kawpow/KPHash.cpp",
-		"xmrig/3rdparty/libethash/keccakf800.c",
-		"xmrig/3rdparty/libethash/ethash_internal.c",
+                "xmrig-override/crypto/kawpow/KPHash.cpp",
+                "xmrig/3rdparty/libethash/keccakf800.c",
+                "xmrig/3rdparty/libethash/ethash_internal.c",
             ],
             "include_dirs": [
                 "xmrig-override",
@@ -89,19 +96,20 @@
             ],
             "cflags_c": [
                 '<!@(uname -a | grep "aarch64" >/dev/null && echo "-march=armv8-a+crypto -flax-vector-conversions -DXMRIG_ARM=1" || (uname -a | grep "armv7" >/dev/null && echo "-mfpu=neon -flax-vector-conversions -DXMRIG_ARM=1" || echo "-march=native"))',
-                '<!@(grep Intel /proc/cpuinfo >/dev/null && echo -DCPU_INTEL || (grep AMD /proc/cpuinfo >/dev/null && (test `awk \'/cpu family/ && $NF~/^[0-9]*$/ {print $NF}\' /proc/cpuinfo | head -n1` -ge 23 && echo -DCPU_AMD || echo -DCPU_AMD_OLD) || echo))',
-                '<!@(grep avx2 /proc/cpuinfo >/dev/null && echo -DHAVE_AVX2 || echo)',
-                '<!@(grep sse2 /proc/cpuinfo >/dev/null && echo -DHAVE_SSE2 || echo)',
-                '<!@(grep ssse3 /proc/cpuinfo >/dev/null && echo -DHAVE_SSSE3 || echo)',
-                '<!@(grep avx512f /proc/cpuinfo >/dev/null && echo -DHAVE_AVX512F || echo)',
-                '<!@(grep xop /proc/cpuinfo >/dev/null && echo -DHAVE_XOP || echo)',
+                '<!@(./check_cpu.sh intel && echo -DCPU_INTEL || (./check_cpu.sh amd && (./check_cpu.sh amdnew && echo -DCPU_AMD || echo -DCPU_AMD_OLD) || echo))',
+                '<!@(./check_cpu.sh avx2 && echo -DHAVE_AVX2 || echo)',
+                '<!@(./check_cpu.sh sse2 && echo -DHAVE_SSE2 || echo)',
+                '<!@(./check_cpu.sh ssse3 && echo -DHAVE_SSSE3 || echo)',
+                '<!@(./check_cpu.sh avx512f && echo -DHAVE_AVX512F || echo)',
+                '<!@(./check_cpu.sh xop && echo -DHAVE_XOP || echo)',
                 "-std=gnu11      -fPIC -DNDEBUG -Ofast -fno-fast-math -w"
             ],
             "cflags_cc": [
                 '<!@(uname -a | grep "aarch64" >/dev/null && echo "-march=armv8-a+crypto -flax-vector-conversions -DXMRIG_ARM=1" || (uname -a | grep "armv7" >/dev/null && echo "-mfpu=neon -flax-vector-conversions -DXMRIG_ARM=1" || echo "-march=native"))',
-                '<!@(grep Intel /proc/cpuinfo >/dev/null && echo -DCPU_INTEL || (grep AMD /proc/cpuinfo >/dev/null && (test `awk \'/cpu family/ && $NF~/^[0-9]*$/ {print $NF}\' /proc/cpuinfo | head -n1` -ge 23 && echo -DCPU_AMD || echo -DCPU_AMD_OLD) || echo))',
+                '<!@(./check_cpu.sh intel && echo -DCPU_INTEL || (./check_cpu.sh amd && (./check_cpu.sh amdnew && echo -DCPU_AMD || echo -DCPU_AMD_OLD) || echo))',
                 "-std=gnu++11 -s -fPIC -DNDEBUG -Ofast -fno-fast-math -fexceptions -fno-rtti -Wno-class-memaccess -w"
-            ]
+            ],
+            'cflags!': [ '-fexceptions' ]
         }
     ]
 }

--- a/check_cpu.sh
+++ b/check_cpu.sh
@@ -1,0 +1,38 @@
+
+set -e
+QUERY="$1"
+
+check_mac() {
+    case "$1" in
+      avx) sysctl -n machdep.cpu.features | grep -i avx >/dev/null;;
+      avx2) sysctl -n machdep.cpu.features | grep -i avx2 >/dev/null;;
+      amd) sysctl -n machdep.cpu.vendor | grep -i amd >/dev/null;;
+      amdnew) sysctl -n machdep.cpu.vendor | grep -i amd && test `sysctl -n machdep.cpu.family` -ge 23;;
+      intel) sysctl -n machdep.cpu.vendor | grep -i intel >/dev/null;;
+      sse2) sysctl -n machdep.cpu.features | grep -i sse2 >/dev/null;;
+      ssse3) sysctl -n machdep.cpu.features | grep -i ssse3 >/dev/null;;
+      avx512f) sysctl -n machdep.cpu.features | grep -i avx512f >/dev/null;;
+      xop) sysctl -n machdep.cpu.features | grep -i xop >/dev/null;;
+      *) echo "UNRECOGNISED CHECK $QUERY"; exit 1; ;;
+    esac
+}
+
+check_linux() {
+    case "$1" in
+      avx) grep avx /proc/cpuinfo >/dev/null;;
+      avx2) grep avx2 /proc/cpuinfo >/dev/null;;
+      amd) grep -i amd /proc/cpuinfo >/dev/null;;
+      amdnew) grep -i amd /proc/cpuinfo && test `awk '/cpu family/ && $NF~/^[0-9]*$/ {print $NF}' | head -n1` -ge 23;;
+      intel) grep -i intel /proc/cpuinfo >/dev/null;;
+      sse2) grep sse2 /proc/cpuinfo >/dev/null;;
+      ssse3) grep ssse3 /proc/cpuinfo >/dev/null;;
+      avx512f) grep avx512f /proc/cpuinfo >/dev/null;;
+      xop) grep xop /proc/cpuinfo >/dev/null;;
+      *) echo "UNRECOGNISED CHECK $QUERY"; exit 1; ;;
+    esac
+}
+
+case "$(uname -a)" in
+  Darwin*) check_mac "$QUERY" ;;
+  *) check_linux "$QUERY" ;;
+esac

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "type": "git",
         "url": "https://github.com/MoneroOcean/node-cryptonight-hashing.git"
     },
-    "dependencies" : {
+    "dependencies": {
         "bindings": "*",
         "nan": "^2.8.0"
     },


### PR DESCRIPTION
Allow builds on macos to work by using sysctl instead of cpuinfo when building on Darwin.
/proc/cpuinfo is used on all linux builds as before

Tested on MacOs and Linux (Ubuntu)