### PR TITLE
Restore CryptoNight-WOW dispatch for algorithm selector 12

### DIFF
--- a/multihashing.cc
+++ b/multihashing.cc
@@ -466,6 +466,7 @@ static xmrig::cn_hash_fun get_cn_fn(const int algo) {
     case 8:  return FNA(CN_2);
     case 9:  return FNA(CN_HALF);
     case 11: return FN(CN_GPU);
+    case 12: return FNA(CN_WOW);
     case 13: return FNA(CN_R);
     case 14: return FNA(CN_RWZ);
     case 15: return FNA(CN_ZLS);


### PR DESCRIPTION
### Motivation
- The native `get_cn_fn()` dispatch removed the `case 12` mapping so calls using selector `12` (documented/tested as CryptoNight-WOW) could silently be routed to the wrong hash implementation, breaking share/hash verification for WOW jobs.

### Description
- Add `case 12: return FNA(CN_WOW);` to `get_cn_fn()` in `multihashing.cc` so selector `12` correctly dispatches to the CryptoNight-WOW implementation while preserving the existing height-dependent API behavior.

### Testing
- Attempted to run `npm test -- tests/test_sync-wow.js` but the test run failed in this environment due to a missing `bindings` module, so automated tests could not complete; the change is a single-line dispatch fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a16107823a88321b1bd8ab7bf4d23ac)