### PR TITLE
Fix worker-thread races in shared native hashing state

### DIFF
--- a/multihashing.cc
+++ b/multihashing.cc
@@ -10,6 +10,7 @@
 #include <memory>
 #include <unistd.h>
 #include <vector>
+#include <mutex>
 
 #if defined(__ARM_ARCH)
   #define my_malloc(a, b) malloc(a)
@@ -271,6 +272,10 @@ static uint8_t        rx_seed_hash[rx_seed_cache_size][32] = {0};
 static uint32_t       rx_seed_algo[rx_seed_cache_size]     = {0};
 static int            rx_active_cache_size                 = rx_seed_cache_size;
 
+static std::mutex randomx_mutex;
+static std::mutex ethash_mutex;
+static std::mutex etchash_mutex;
+
 struct InitCtx {
     InitCtx() {
         xmrig::CnCtx::create(&ctx, static_cast<uint8_t*>(my_malloc(max_mem_size, 4096)), max_mem_size, 1);
@@ -279,7 +284,7 @@ struct InitCtx {
 } s;
 
 void init_rx(const uint8_t* seed_hash_data, xmrig::Algorithm::Id algo) {
-    bool update_cache = false;
+    std::lock_guard<std::mutex> lock(randomx_mutex);
     const int rxid = rx2id(algo);
     assert(rxid < MAXRX);
 
@@ -433,7 +438,10 @@ NAN_METHOD(randomx) {
     }
 
     char output[32];
-    randomx_calculate_hash(rx_vm[rx2id(xalgo)], reinterpret_cast<const uint8_t*>(Buffer::Data(target)), Buffer::Length(target), reinterpret_cast<uint8_t*>(output), xalgo);
+    {
+        std::lock_guard<std::mutex> lock(randomx_mutex);
+        randomx_calculate_hash(rx_vm[rx2id(xalgo)], reinterpret_cast<const uint8_t*>(Buffer::Data(target)), Buffer::Length(target), reinterpret_cast<uint8_t*>(output), xalgo);
+    }
 
     v8::Local<v8::Value> returnValue = Nan::CopyBuffer(output, 32).ToLocalChecked();
     info.GetReturnValue().Set(returnValue);
@@ -1094,15 +1102,19 @@ NAN_METHOD(ethash) {
 	memcpy(&header_hash, reinterpret_cast<const uint8_t*>(Buffer::Data(header_hash_buff)), sizeof(header_hash));
         const uint64_t nonce = __builtin_bswap64(*(reinterpret_cast<const uint64_t*>(Buffer::Data(nonce_buff))));
 
-        static int prev_epoch = 0;
-        static ethash_light_t cache = nullptr;
-        const int epoch = height / ETHASH_EPOCH_LENGTH;
-        if (prev_epoch != epoch) {
-            if (cache) ethash_light_delete(cache);
-            cache = ethash_light_new(height, epoch, epoch);
-            prev_epoch = epoch;
+        ethash_return_value_t res;
+        {
+            std::lock_guard<std::mutex> lock(ethash_mutex);
+            static int prev_epoch = 0;
+            static ethash_light_t cache = nullptr;
+            const int epoch = height / ETHASH_EPOCH_LENGTH;
+            if (prev_epoch != epoch) {
+                if (cache) ethash_light_delete(cache);
+                cache = ethash_light_new(height, epoch, epoch);
+                prev_epoch = epoch;
+            }
+            res = ethash_light_compute(cache, header_hash, nonce);
         }
-        ethash_return_value_t res = ethash_light_compute(cache, header_hash, nonce);
 
         v8::Local<v8::Array> returnValue = v8::Array::New(isolate, 2);
         SetArrayValue(isolate, returnValue, 0, Nan::CopyBuffer((char*)&res.result.b[0], 32).ToLocalChecked());
@@ -1130,17 +1142,21 @@ NAN_METHOD(etchash) {
 	memcpy(&header_hash, reinterpret_cast<const uint8_t*>(Buffer::Data(header_hash_buff)), sizeof(header_hash));
         const uint64_t nonce = __builtin_bswap64(*(reinterpret_cast<const uint64_t*>(Buffer::Data(nonce_buff))));
 
-        static int prev_epoch_seed = 0;
-        static ethash_light_t cache = nullptr;
-        const int epoch_length = height >= ETCHASH_EPOCH_HEIGHT ? ETCHASH_EPOCH_LENGTH : ETHASH_EPOCH_LENGTH;
-        const int epoch       = height / epoch_length;
-        const int epoch_seed  = (epoch * epoch_length + 1) / ETHASH_EPOCH_LENGTH;
-        if (prev_epoch_seed != epoch_seed) {
-            if (cache) ethash_light_delete(cache);
-            cache = ethash_light_new(height, epoch_seed, epoch);
-            prev_epoch_seed = epoch_seed;
+        ethash_return_value_t res;
+        {
+            std::lock_guard<std::mutex> lock(etchash_mutex);
+            static int prev_epoch_seed = 0;
+            static ethash_light_t cache = nullptr;
+            const int epoch_length = height >= ETCHASH_EPOCH_HEIGHT ? ETCHASH_EPOCH_LENGTH : ETHASH_EPOCH_LENGTH;
+            const int epoch       = height / epoch_length;
+            const int epoch_seed  = (epoch * epoch_length + 1) / ETHASH_EPOCH_LENGTH;
+            if (prev_epoch_seed != epoch_seed) {
+                if (cache) ethash_light_delete(cache);
+                cache = ethash_light_new(height, epoch_seed, epoch);
+                prev_epoch_seed = epoch_seed;
+            }
+            res = ethash_light_compute(cache, header_hash, nonce);
         }
-        ethash_return_value_t res = ethash_light_compute(cache, header_hash, nonce);
 
         v8::Local<v8::Array> returnValue = v8::Array::New(isolate, 2);
         SetArrayValue(isolate, returnValue, 0, Nan::CopyBuffer((char*)&res.result.b[0], 32).ToLocalChecked());


### PR DESCRIPTION
### Motivation
- The native addon is registered as `NODE_MODULE_CONTEXT_AWARE` while RandomX, ethash and etchash use process-wide mutable state, allowing concurrent worker threads to race and cause use-after-free or crashes. 
- Make the minimal changes needed so the shared native hashing state is safe to use from multiple Node contexts/workers.

### Description
- Add `#include <mutex>` and introduce three process-wide mutexes: `randomx_mutex`, `ethash_mutex`, and `etchash_mutex` to protect shared state. 
- Serialize RandomX global state mutations inside `init_rx` with a `std::lock_guard<std::mutex>` and protect `randomx_calculate_hash` calls with the same mutex. 
- Wrap the `ethash` and `etchash` light-cache replacement and subsequent `ethash_light_compute` calls in `std::lock_guard` blocks to prevent concurrent delete/compute races. 
- Keep the public API and single-threaded behavior unchanged while providing process-wide serialization to mitigate UAF/crash races.

### Testing
- Ran `npm test` in this environment and it failed before exercising the native addon due to a missing JS dependency (`bindings`), so functional verification of the addon build/behavior could not complete here. 
- No other automated tests were run in this environment; recommend running full CI/build to validate native builds and multi-worker concurrency tests that exercise `ethash`/`etchash` and `randomx` paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a15fd2251ac83218098a49285251f21)